### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/EF.Core.Database.Adapter/security/code-scanning/10](https://github.com/BoBoBaSs84/EF.Core.Database.Adapter/security/code-scanning/10)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. For a typical CI workflow that only checks out code and runs builds/tests, `contents: read` is sufficient. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. No changes to the jobs or steps are needed, and no additional imports or dependencies are required.